### PR TITLE
TranslateBody Boiler Plate 제거

### DIFF
--- a/translator_without_state_management/lib/presentation/layout/translate_body.dart
+++ b/translator_without_state_management/lib/presentation/layout/translate_body.dart
@@ -8,20 +8,9 @@ class TranslateBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          return SingleChildScrollView(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minHeight: constraints.maxHeight,
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: TranslateInputTextField(onChnagedText: onChangedText),
-              ),
-            ),
-          );
-        },
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: TranslateInputTextField(onChnagedText: onChangedText),
       ),
     );
   }


### PR DESCRIPTION
TextField는 Overflow를 불러일으키지 않고 Expaneded만으로 LayoutBuilder + ConstraintedBox의 효과를 낼 수 있기 때문에 해당 부분 삭제